### PR TITLE
Allow passing along options to the S3 client

### DIFF
--- a/FilesystemManager.php
+++ b/FilesystemManager.php
@@ -188,7 +188,7 @@ class FilesystemManager implements FactoryContract
         $root = isset($s3Config['root']) ? $s3Config['root'] : null;
 
         return $this->adapt($this->createFlysystem(
-            new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root), $config
+            new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root, $config['options'] ?: []), $config
         ));
     }
 


### PR DESCRIPTION
I found that adding cache control or similar is not possible natively. This allows you to use it by adding a new key to your array in filesystems.php (Laravel)

```
    'options' => [
        'CacheControl' => '...'
    ]
```

Any other solution would be greatly appreciated
