### PR TITLE
[9.x] Filesystem get Visibility should only throw if driver set to throw

### DIFF
--- a/FilesystemAdapter.php
+++ b/FilesystemAdapter.php
@@ -418,8 +418,13 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function getVisibility($path)
     {
-        if ($this->driver->visibility($path) == Visibility::PUBLIC) {
-            return FilesystemContract::VISIBILITY_PUBLIC;
+
+        try  {
+            if ($this->driver->visibility($path) == Visibility::PUBLIC) {
+                return FilesystemContract::VISIBILITY_PUBLIC;
+            }
+        }catch(UnableToRetrieveMetadata $e){
+            throw_if($this->throwsExceptions(), $e);
         }
 
         return FilesystemContract::VISIBILITY_PRIVATE;


### PR DESCRIPTION
Issue that arises when checking visibility if the s3 bucket is not set with ACL's and the config for s3 is set to not throw exceptions.